### PR TITLE
Use shell=False in subprocess Function Calls

### DIFF
--- a/jtd_codebuild/generators/generator.py
+++ b/jtd_codebuild/generators/generator.py
@@ -68,8 +68,7 @@ class JTDCodeGenerator:
         safe_mkdir(target_path)
         process = subprocess.Popen(
             self._codegen_command(self.schema_path, target_path, target_language),
-            shell=True,
-            stdout=subprocess.PIPE,
+            shell=False, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
         return [process]

--- a/jtd_codebuild/generators/typescript_generator.py
+++ b/jtd_codebuild/generators/typescript_generator.py
@@ -21,8 +21,7 @@ class JTDCodeGeneratorTypescriptTarget(JTDCodeGenerator):
         """
         return subprocess.run(
             f"tsc --project {tsconfig_path}",
-            shell=True,
-            stdout=subprocess.PIPE,
+            shell=False, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
 

--- a/jtd_codebuild/loaders.py
+++ b/jtd_codebuild/loaders.py
@@ -38,7 +38,7 @@ def load_definitions(cwd: str) -> Dict[AnyStr, Any]:
                 filepath = join(root, file)
                 with open(filepath, "r") as f:
                     definition_parts = (
-                        yaml.load(f, Loader=yaml.FullLoader)
+                        yaml.load(f, Loader=yaml.SafeLoader)
                         if file_is_yaml(file)
                         else json.load(f)
                     )
@@ -66,7 +66,7 @@ def load_root_schema(cwd: str) -> Dict[AnyStr, Any]:
 
     with open(schema_path, "r") as f:
         return (
-            yaml.load(f, Loader=yaml.FullLoader)
+            yaml.load(f, Loader=yaml.SafeLoader)
             if file_is_yaml(schema_path)
             else json.load(f)
         )

--- a/jtd_codebuild/tests/test_example_project_1.py
+++ b/jtd_codebuild/tests/test_example_project_1.py
@@ -14,8 +14,7 @@ def test_example_project_1():
     # Run the command
     subprocess.check_call(
         "jtd-codebuild fixtures/example_project_1",
-        shell=True,
-        cwd=cwd,
+        shell=False, cwd=cwd,
     )
 
     # Check the output

--- a/jtd_codebuild/tests/test_example_project_2.py
+++ b/jtd_codebuild/tests/test_example_project_2.py
@@ -13,8 +13,7 @@ def test_example_project_2():
     # Run the command
     subprocess.check_call(
         "jtd-codebuild fixtures/example_project_2",
-        shell=True,
-        cwd=cwd,
+        shell=False, cwd=cwd,
     )
 
     # Check the output

--- a/jtd_codebuild/tests/test_example_project_3.py
+++ b/jtd_codebuild/tests/test_example_project_3.py
@@ -13,8 +13,7 @@ def test_example_project_3():
     # Run the command
     subprocess.check_call(
         "jtd-codebuild fixtures/example_project_3",
-        shell=True,
-        cwd=cwd,
+        shell=False, cwd=cwd,
     )
 
     # Check the output

--- a/jtd_codebuild/tests/test_example_project_4.py
+++ b/jtd_codebuild/tests/test_example_project_4.py
@@ -13,8 +13,7 @@ def test_example_project_4():
     # Run the command
     subprocess.check_call(
         "jtd-codebuild fixtures/example_project_4",
-        shell=True,
-        cwd=cwd,
+        shell=False, cwd=cwd,
     )
 
     # Check the output


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This codemod sets the `shell` keyword argument to `False` in `subprocess` module function calls that have set it to `True`.

Setting `shell=True` will execute the provided command through the system shell which can lead to shell injection vulnerabilities. In the worst case this can give an attacker the ability to run arbitrary commands on your system. In most cases using `shell=False` is sufficient and leads to much safer code.

The changes from this codemod look like this:

```diff
 import subprocess
- subprocess.run("echo 'hi'", shell=True)
+ subprocess.run("echo 'hi'", shell=False)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python.org/3/library/subprocess.html#security-considerations](https://docs.python.org/3/library/subprocess.html#security-considerations)
  * [https://en.wikipedia.org/wiki/Code_injection#Shell_injection](https://en.wikipedia.org/wiki/Code_injection#Shell_injection)
  * [https://stackoverflow.com/a/3172488](https://stackoverflow.com/a/3172488)
</details>


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](./CONTRIBUTING.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Update the corresponding documentation if needed.
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
