### PR TITLE
Simplify Boolean Expressions Using `startswith` and `endswith`

### DIFF
--- a/jtd_codebuild/utils.py
+++ b/jtd_codebuild/utils.py
@@ -63,7 +63,7 @@ def file_is_yaml(file: str) -> bool:
     Returns:
         True if the file is a YAML file, False otherwise.
     """
-    return file.endswith(".yaml") or file.endswith(".yml")
+    return file.endswith((".yaml", ".yml"))
 
 
 def file_is_json(file: str) -> bool:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Many developers are not necessarily aware that the `startswith` and `endswith` methods of `str` objects can accept a tuple of strings to match. This means that there is a lot of code that uses boolean expressions such as `x.startswith('foo') or x.startswith('bar')` instead of the simpler expression `x.startswith(('foo', 'bar'))`.

This codemod simplifies the boolean expressions where possible which leads to cleaner and more concise code.

The changes from this codemod look like this:

```diff
  x = 'foo'
- if x.startswith("foo") or x.startswith("bar"):
+ if x.startswith(("foo", "bar")):
     ...
```

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/combine-startswith-endswith](https://docs.pixee.ai/codemods/python/pixee_python_combine-startswith-endswith)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fjtd-codebuild%7C3f52a76c1f56329791359e9ea951feaaecd0fa14)

<!--{"type":"DRIP","codemod":"pixee:python/combine-startswith-endswith"}-->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
